### PR TITLE
#114 fix bug where a new request was created instead of overriding a …

### DIFF
--- a/src/cms-client/src/app/edit-form/edit-form.component.ts
+++ b/src/cms-client/src/app/edit-form/edit-form.component.ts
@@ -80,6 +80,7 @@ export class EditFormComponent {
       });
       this.api.getCourse(editedId).subscribe(data => {
         this.courseEditable = data;
+        this.courseEditable.id = Number(originalId);
         this.setRequisitesStrings(data, this.editedModel);
       });
     }


### PR DESCRIPTION
This change fixes #114, the mistake that the id of the edited side was not changed to the original ID, causing the new request to be created. As opposed to the analysis in the issue, both left and right sides need the same ID, any versioning tracking would be kept by the backend and database, so the target id does not have any use in the front end.