### PR TITLE
[#185] Add pipeline audit backend

### DIFF
--- a/src/cms-api/src/main/java/com/soen490/cms/Controllers/ApprovalPipelineController.java
+++ b/src/cms-api/src/main/java/com/soen490/cms/Controllers/ApprovalPipelineController.java
@@ -181,4 +181,10 @@ public class ApprovalPipelineController {
             return false;
         }
     }
+
+
+    @GetMapping("/pipeline_revisions")
+    public List getPipelineRevisions(@RequestParam int pipeline_id){
+        return approvalPipelineService.getPipelineRevisions(pipeline_id);
+    }
 }

--- a/src/cms-api/src/main/java/com/soen490/cms/Models/ApprovalPipelineRequestPackage.java
+++ b/src/cms-api/src/main/java/com/soen490/cms/Models/ApprovalPipelineRequestPackage.java
@@ -2,10 +2,13 @@ package com.soen490.cms.Models;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
+import org.hibernate.envers.Audited;
 
 import javax.persistence.*;
 import java.io.Serializable;
 import java.sql.Timestamp;
+
+import static org.hibernate.envers.RelationTargetAuditMode.NOT_AUDITED;
 
 @Entity
 @Data
@@ -23,8 +26,10 @@ public class ApprovalPipelineRequestPackage implements Serializable {
     @JoinColumn(name = "package_id")
     private RequestPackage requestPackage;
 
+    @Audited
     private String position;
 
+    @Audited(targetAuditMode = NOT_AUDITED)
     @JsonIgnoreProperties({"supportingDocuments", "requests", "approvals", "approvalPipelineRequestPackages"})
     @ManyToOne
     @JoinColumn(name = "user_id")

--- a/src/cms-api/src/main/java/com/soen490/cms/Models/PipelineRevision.java
+++ b/src/cms-api/src/main/java/com/soen490/cms/Models/PipelineRevision.java
@@ -1,0 +1,21 @@
+package com.soen490.cms.Models;
+
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.math.BigInteger;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class PipelineRevision extends Revision{
+
+    String from_position;
+    String to_position;
+
+    public PipelineRevision(int id, int rev, int revtype, BigInteger timestamp, User user, String to_position){
+        super(id, rev, revtype, timestamp, user);
+        this.from_position = user.getUserType();
+        this.to_position = to_position;
+    }
+}

--- a/src/cms-api/src/main/java/com/soen490/cms/Models/User.java
+++ b/src/cms-api/src/main/java/com/soen490/cms/Models/User.java
@@ -32,7 +32,7 @@ import java.util.List;
 
 @Entity
 @Data
-@ToString(exclude= {"requests", "approvals", "department"})
+@ToString(exclude= {"requests", "department"})
 public class User {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/cms-api/src/main/java/com/soen490/cms/Repositories/ApprovalPipelineRequestPackageRepository.java
+++ b/src/cms-api/src/main/java/com/soen490/cms/Repositories/ApprovalPipelineRequestPackageRepository.java
@@ -4,6 +4,7 @@ import com.soen490.cms.Models.ApprovalPipelineRequestPackage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.history.RevisionRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,7 +12,8 @@ import java.util.Collection;
 import java.util.List;
 
 @Repository
-public interface ApprovalPipelineRequestPackageRepository extends JpaRepository<ApprovalPipelineRequestPackage, Integer> {
+public interface ApprovalPipelineRequestPackageRepository extends JpaRepository<ApprovalPipelineRequestPackage, Integer>,
+        RevisionRepository<ApprovalPipelineRequestPackage, Integer, Integer> {
 
     @Query(value = "SELECT * FROM approval_pipeline_request_package WHERE pipeline_id=?1 AND package_id=?2", nativeQuery = true)
     ApprovalPipelineRequestPackage findApprovalPipelineRequestPackage(int pipelineId, int packageId);
@@ -23,4 +25,9 @@ public interface ApprovalPipelineRequestPackageRepository extends JpaRepository<
     @Modifying
     @Query(value = "DELETE FROM approval_pipeline_request_package WHERE pipeline_id=?1 AND package_id=?2", nativeQuery = true)
     void remove(int pipelineId, int packageId);
+
+
+    @Query(value = "SELECT rpa.pipeline_id, rpa.rev, rpa.revtype, r.revtstmp, rpa.user_id, rpa.position FROM " +
+            "approval_pipeline_request_package_aud rpa, revinfo r WHERE rpa.rev=r.rev AND rpa.pipeline_id=?", nativeQuery = true)
+    List<Object[]> getRevisions(int id);
 }

--- a/src/cms-api/src/main/java/com/soen490/cms/Services/PipelineService/ApprovalPipelineService.java
+++ b/src/cms-api/src/main/java/com/soen490/cms/Services/PipelineService/ApprovalPipelineService.java
@@ -1,9 +1,6 @@
 package com.soen490.cms.Services.PipelineService;
 
-import com.soen490.cms.Models.ApprovalPipeline;
-import com.soen490.cms.Models.ApprovalPipelineRequestPackage;
-import com.soen490.cms.Models.RequestPackage;
-import com.soen490.cms.Models.User;
+import com.soen490.cms.Models.*;
 import com.soen490.cms.Repositories.ApprovalPipelineRepository;
 import com.soen490.cms.Repositories.ApprovalPipelineRequestPackageRepository;
 import com.soen490.cms.Repositories.RequestPackageRepository;
@@ -15,6 +12,7 @@ import org.json.JSONException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.math.BigInteger;
 import java.util.*;
 
 @Log4j2
@@ -390,5 +388,22 @@ public class ApprovalPipelineService {
     public List<ApprovalPipeline> getPipelineByPackageId(int package_id) {
 
         return approvalPipelineRepository.findByPackageId(package_id);
+    }
+
+    public List getPipelineRevisions(int id) {
+
+        log.info("Retrieving revision history for pipeline " + id + ".");
+
+        List<Object[]> revisions = approvalPipelineRequestPackageRepository.getRevisions(id);
+
+        List<PipelineRevision> versions = new ArrayList<>();
+
+        if (revisions.isEmpty()) return null;
+
+        for (Object[] r : revisions)
+            versions.add(new PipelineRevision((Integer) r[0], (Integer) r[1], (Byte) r[2],(BigInteger) r[3],
+                    userRepository.findUserById((Integer) r[4]), (String) r[5]));
+
+        return versions;
     }
 }


### PR DESCRIPTION
- endpoint reachable at /pipeline_revisions. Given a pipeline_id, it
  returns info on who moved a dossier down the pipeline with a timestamp.

PR related to issue #185.

![image](https://user-images.githubusercontent.com/19395031/72851569-fe194600-3c79-11ea-835c-819d30bc0d1c.png)



